### PR TITLE
Remove flag attribute from country data

### DIFF
--- a/utils/getCountry.js
+++ b/utils/getCountry.js
@@ -20,6 +20,8 @@ module.exports = async (spinner, table, states, country) => {
 			process.exit(0);
 		}
 		let data = Object.values(api.data);
+		let flagIndex = 1;
+		data.splice(flagIndex, 1);
 		data = data.map(d => comma(d));
 		table.push(data);
 		spinner.stopAndPersist();


### PR DESCRIPTION
corona.lmao.ninja API has added flag information in response while calling API for country stats.
Previous format:
```
[ 'India', 468, 72, 9, 2, 24, 435, 0, 0 ]
```
Updated format:
```
[
  'India',
  {
    iso2: 'IN',
    iso3: 'IND',
    _id: 356,
    lat: 20,
    long: 77,
    flag: 'https://raw.githubusercontent.com/NovelCOVID/API/master/assets/flags/in.png'
  },
  468,
  72,
  9,
  2,
  24,
  435,
  0,
  0
]
```