### PR TITLE
fix for table numbers not lining up correctly when displaying all countries

### DIFF
--- a/utils/getAll.js
+++ b/utils/getAll.js
@@ -6,7 +6,10 @@ const { sortKeys, sortOrders } = require("./table.js");
 module.exports = async (spinner, table, states, country, options) => {
 	if (!country && !states) {
 		const api = await axios.get(`https://corona.lmao.ninja/countries`);
-		let all = api.data.map(one => Object.values(one));
+		let all = api.data.map(one => {
+			const {countryInfo, ...rest } = one;
+			return Object.values(rest)
+		});
 
 		const sortIndex = sortKeys.indexOf(options.sort);
 


### PR DESCRIPTION
Fixes #27 

# Description

By changing the `all` variable in the `getAll.js` file to not include the `countryInfo` property from the api response data we return the correct number of fields which fixes the issue for the `getAll.js` file so that all the data lines up with the correct headers in the table when displaying all the countries.

- [X] Bug fix (non-breaking change which fixes an issue)

