### PR TITLE
Fix the country table not displaying numbers in the correct column

### DIFF
--- a/utils/getCountry.js
+++ b/utils/getCountry.js
@@ -19,7 +19,9 @@ module.exports = async (spinner, table, states, country) => {
 			);
 			process.exit(0);
 		}
-		let data = Object.values(api.data);
+		// we don't need the countryInfo data so seperate that from the rest of data (restData)
+		const {countryInfo, ...restData} = api.data
+		let data = Object.values(restData);
 		data = data.map(d => comma(d));
 		table.push(data);
 		spinner.stopAndPersist();


### PR DESCRIPTION
Fixes #27 

# Description

In the `getCountry.js` file remove the unwanted `countryInfo` property causing the issue #27 from the api response data by destructuring the response `api.data` object into `countryInfo` and `restData` (representing the rest of the object data minus countryInfo), then passing the filtered `restData` to the `let data = Object.values(restData)` line.

- [X] Bug fix (non-breaking change which fixes an issue)