### PR TITLE
🐛 FIX: error message for countries not found or without cases

### DIFF
--- a/utils/getCountry.js
+++ b/utils/getCountry.js
@@ -11,18 +11,19 @@ module.exports = async (spinner, table, states, countryName) => {
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/countries/${countryName}`)
 		);
-		handleError(`API is down, try again later.`, err, false);
-		const thisCountry = response.data;
 
-		if (response.data === 'Country not found') {
+		if (err && err.response.status === 404) {
 			spinner.stopAndPersist();
 			console.log(
 				`${red(
-					`${sym.error} Nops. A country named "${countryName}" does not exist…`
+					`${sym.error} Oops. A country named "${countryName}" does not exist or has no cases...`
 				)}\n`
 			);
 			process.exit(0);
 		}
+		
+		handleError(`API is down, try again later.`, err, false);
+		const thisCountry = response.data;
 
 		table.push([
 			`—`,


### PR DESCRIPTION
 ## Error message for countries not found or without cases

Initially, when users input countries that don't exist or without cases, they get an "API down message". But this has been corrected. View screenshots below

Before: 
![1](https://user-images.githubusercontent.com/37238033/77740266-3b4fda80-7013-11ea-936d-55961b7dd70c.PNG)

After:
![2](https://user-images.githubusercontent.com/37238033/77740296-473b9c80-7013-11ea-9c36-c9735397c579.PNG)
