### PR TITLE
📦 NEW: Option --date

### DIFF
--- a/utils/cli.js
+++ b/utils/cli.js
@@ -18,6 +18,7 @@ module.exports = meow(
 	  ${yellow(`--sort`)}, ${yellow(`-s`)}           Sort data by type
 	  ${yellow(`--reverse`)}, ${yellow(`-r`)}        Reverse print order
 	  ${yellow(`--limit`)}, ${yellow(`-l`)}          Print only N entries
+	  ${yellow(`--date`)}, ${yellow(`-d`)}           Print report for particular date
 
 	Examples
 	  ${green(`corona`)} ${cyan(`china`)}
@@ -53,6 +54,14 @@ module.exports = meow(
 				type: 'number',
 				default: Number.MAX_SAFE_INTEGER,
 				alias: 'l'
+			},
+			date: {
+				type: 'string',
+				default: new Date()
+					.toISOString()
+					.slice(0, 10)
+					.replace(/-/g, ''),
+				alias: 'd'
 			},
 			minimal: {
 				type: 'boolean',

--- a/utils/commonUtils.js
+++ b/utils/commonUtils.js
@@ -5,7 +5,7 @@ const handleError = require('cli-handle-error');
 
 const dim = chalk.dim;
 const red = chalk.red;
-const DATE_CHAR = 8;
+const DATE_CHAR = 6;
 
 let validateDateFormat = function (inputDate) {
 	var inputDateLength = inputDate.length;
@@ -21,13 +21,14 @@ let validateDateFormat = function (inputDate) {
 };
 
 let getNinjaDateFormat = function (inputDate) {
-	// convert YYYYMMDD to YYYY-MM--DD
+	// convert DDMMYY to YYYY-MM-DD
 	var formattedDate =
-		inputDate.slice(0, 4) +
-		'-' +
+		'20' +
 		inputDate.slice(4, 6) +
 		'-' +
-		inputDate.slice(6, 8);
+		inputDate.slice(2, 4) +
+		'-' +
+		inputDate.slice(0, 2);
 	var newDate = new Date(formattedDate);
 	var year = newDate.getFullYear().toString().substr(-2);
 	var month = newDate.getMonth() + 1 + '';
@@ -52,11 +53,12 @@ let throwError = function (error) {
 
 let isPastDate = function (inputDate) {
 	var formatInputDate = new Date(
-		inputDate.slice(0, 4) +
-			'-' +
+		'20' +
 			inputDate.slice(4, 6) +
 			'-' +
-			inputDate.slice(6, 8)
+			inputDate.slice(2, 4) +
+			'-' +
+			inputDate.slice(0, 2)
 	);
 	var today = new Date();
 	today.setHours(0, 0, 0, 0);

--- a/utils/commonUtils.js
+++ b/utils/commonUtils.js
@@ -1,0 +1,69 @@
+const axios = require('axios');
+const chalk = require('chalk');
+const sym = require('log-symbols');
+const handleError = require('cli-handle-error');
+
+const dim = chalk.dim;
+const red = chalk.red;
+const DATE_CHAR = 8;
+
+let validateDateFormat = function (inputDate) {
+	var inputDateLength = inputDate.length;
+	if (inputDateLength != DATE_CHAR) {
+		return false;
+	}
+	for (index = 0; index < inputDateLength; index++) {
+		if (inputDate[index] < '0' || inputDate[index] > '9') {
+			return false;
+		}
+	}
+	return true;
+};
+
+let getNinjaDateFormat = function (inputDate) {
+	// convert YYYYMMDD to YYYY-MM--DD
+	var formattedDate =
+		inputDate.slice(0, 4) +
+		'-' +
+		inputDate.slice(4, 6) +
+		'-' +
+		inputDate.slice(6, 8);
+	var newDate = new Date(formattedDate);
+	var year = newDate.getFullYear().toString().substr(-2);
+	var month = newDate.getMonth() + 1 + '';
+	var day = newDate.getDate();
+	var ninjaDate = month + '/' + day + '/' + year;
+	return ninjaDate;
+};
+
+let throwError = function (error) {
+	switch (error.type) {
+		case 'OPTIONS_VALIDATION':
+			console.log(
+				`${red(
+					`${sym.error} Options validation failed.${error.message}`
+				)}\n`
+			);
+			break;
+		default:
+			console.log(`${sym.error} ${dim(`Error format is wrong`)}`);
+	}
+};
+
+let isPastDate = function (inputDate) {
+	var formatInputDate = new Date(
+		inputDate.slice(0, 4) +
+			'-' +
+			inputDate.slice(4, 6) +
+			'-' +
+			inputDate.slice(6, 8)
+	);
+	var today = new Date();
+	today.setHours(0, 0, 0, 0);
+	return today > formatInputDate;
+};
+
+module.exports.validateDateFormat = validateDateFormat;
+module.exports.throwError = throwError;
+module.exports.getNinjaDateFormat = getNinjaDateFormat;
+module.exports.isPastDate = isPastDate;

--- a/utils/getCountry.js
+++ b/utils/getCountry.js
@@ -3,15 +3,27 @@ const axios = require('axios');
 const sym = require('log-symbols');
 const comma = require('comma-number');
 const red = chalk.red;
+const dim = chalk.dim;
 const to = require('await-to-js').default;
 const handleError = require('cli-handle-error');
+const commonUtils = require('./commonUtils');
 
-module.exports = async (spinner, table, states, countryName) => {
+module.exports = async (
+	spinner,
+	table,
+	states,
+	countryName,
+	{ sortBy, limit, reverse, date }
+) => {
 	if (countryName && !states) {
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/countries/${countryName}`)
 		);
-		handleError(`API is down, try again later.`, err, false);
+		handleError(
+			`API endpoint GET /countries is down, try again later.`,
+			err,
+			false
+		);
 		const thisCountry = response.data;
 
 		if (response.data === 'Country not found') {
@@ -22,6 +34,38 @@ module.exports = async (spinner, table, states, countryName) => {
 				)}\n`
 			);
 			process.exit(0);
+		}
+
+		// get historical data if date option is provided
+		if (commonUtils.isPastDate(date)) {
+			const [err, historicalDataresponse] = await to(
+				axios.get(
+					`https://corona.lmao.ninja/v2/historical/${countryName}`
+				)
+			);
+			handleError(
+				`API endpoint GET /v2/historical is down, try again later.`,
+				err,
+				false
+			);
+			const thisCountryHistoricalDate = historicalDataresponse.data;
+			var ninjaDateFormat = commonUtils.getNinjaDateFormat(date);
+			table.options.head[3] = `Cases ${dim(`(${ninjaDateFormat})`)}`;
+			table.options.head[5] = `Deaths ${red(`(${ninjaDateFormat})`)}`;
+			thisCountry.todayCases =
+				ninjaDateFormat in
+				thisCountryHistoricalDate['timeline']['cases']
+					? thisCountryHistoricalDate['timeline']['cases'][
+							ninjaDateFormat
+					  ]
+					: '-';
+			thisCountry.todayDeaths =
+				ninjaDateFormat in
+				thisCountryHistoricalDate['timeline']['deaths']
+					? thisCountryHistoricalDate['timeline']['deaths'][
+							ninjaDateFormat
+					  ]
+					: '-';
 		}
 
 		table.push([

--- a/utils/getStates.js
+++ b/utils/getStates.js
@@ -8,7 +8,12 @@ const to = require('await-to-js').default;
 const handleError = require('cli-handle-error');
 const orderBy = require('lodash.orderby');
 
-module.exports = async (spinner, table, states, { sortBy, limit, reverse }) => {
+module.exports = async (
+	spinner,
+	table,
+	states,
+	{ sortBy, limit, reverse, date }
+) => {
 	if (states) {
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/states`)

--- a/utils/validateOptions.js
+++ b/utils/validateOptions.js
@@ -1,0 +1,17 @@
+const commonUtils = require('./commonUtils');
+
+module.exports = function (options) {
+	var validationResult = {
+		status: false,
+		type: '',
+		error: []
+	};
+	if (!commonUtils.validateDateFormat(options.date)) {
+		validationResult.status = true;
+		(validationResult.type = 'OPTIONS_VALIDATION'),
+			validationResult.error.push(
+				'`date` option must be in format YYYYMMDD'
+			);
+	}
+	return validationResult;
+};


### PR DESCRIPTION
This is new feature request for [ISSUE-33](https://github.com/ahmadawais/corona-cli/issues/33) which is adding `--date` option to our cool `corona-cli`

Current implementation is valid for `corona <country-name>`

```
  Track the Coronavirus disease (COVID-19).

  Usage
    corona <command> [--option]

  Commands
    country-name         Get data for a given country
    states               Get data for all USA states

  Options
    --xcolor, -x         Single colored output
    --sort, -s           Sort data by type
    --reverse, -r        Reverse print order
    --limit, -l          Print only N entries
    --date, -d           Print report for particular date

  Examples
    corona china
    corona states
    corona -x
    corona --sort cases-today
    corona -s critical

  ❯ You can also run command + option at once:
    corona china -x -s cases
```