### PR TITLE
NEW: Implement full JSON output, without changing existing logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ process.on('unhandledRejection', err => {
 const ora = require('ora');
 const spinner = ora({ text: '' });
 const Table = require('cli-table3');
+const JsonOutput = require('./utils/JsonOutput.js');
 const cli = require('./utils/cli.js');
 const init = require('./utils/init.js');
 const theEnd = require('./utils/theEnd.js');
@@ -37,11 +38,12 @@ const limit = Math.abs(cli.flags.limit);
 const chart = cli.flags.chart;
 const log = cli.flags.log;
 const minimal = cli.flags.minimal;
-const options = { sortBy, limit, reverse, minimal, chart, log };
+const json = cli.flags.json;
+const options = { sortBy, limit, reverse, minimal, chart, log, json };
 
 (async () => {
 	// Init.
-	init(minimal);
+	init(minimal || json);
 	input === 'help' && (await cli.showHelp(0));
 	const states = input === 'states' ? true : false;
 	const country = input;
@@ -50,17 +52,18 @@ const options = { sortBy, limit, reverse, minimal, chart, log };
 	const head = xcolor ? single : colored;
 	const headStates = xcolor ? singleStates : coloredStates;
 	const border = minimal ? borderless : {};
-	const table = !states
-		? new Table({ head, style, chars: border })
-		: new Table({ head: headStates, style, chars: border });
+	const OutputFormat = json ? JsonOutput : Table;
+	const output = !states
+		? new OutputFormat({ head, style, chars: border })
+		: new OutputFormat({ head: headStates, style, chars: border });
 
 	// Display data.
 	spinner.start();
-	const lastUpdated = await getWorldwide(table, states);
-	await getCountry(spinner, table, states, country, options);
-	await getStates(spinner, table, states, options);
-	await getCountries(spinner, table, states, country, options);
+	const lastUpdated = await getWorldwide(output, states);
+	await getCountry(spinner, output, states, country, options);
+	await getStates(spinner, output, states, options);
+	await getCountries(spinner, output, states, country, options);
 	await getCountryChart(spinner, country, options);
 
-	theEnd(lastUpdated, states, minimal);
+	theEnd(lastUpdated, states, minimal, output);
 })();

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ const options = { sortBy, limit, reverse, minimal, chart, log, json };
 
 	// Display data.
 	spinner.start();
-	const lastUpdated = await getWorldwide(output, states);
+	const lastUpdated = await getWorldwide(output, states, json);
 	await getCountry(spinner, output, states, country, options);
 	await getStates(spinner, output, states, options);
 	await getCountries(spinner, output, states, country, options);

--- a/utils/JsonOutput.js
+++ b/utils/JsonOutput.js
@@ -1,0 +1,25 @@
+class JsonOutput {
+  constructor(options) {
+    this.options = options;
+    this.values = [];
+  }
+
+  get asObject() {
+    return this.values.map(values => {
+      return values.reduce((acc, value, index) => {
+        acc[this.options.head[index]] = value;
+        return acc;
+      }, {});
+    });
+  }
+
+  push(value) {
+    this.values.push(value);
+  }
+
+  format() {
+    return JSON.stringify(this.asObject);
+  }
+}
+
+module.exports = JsonOutput;

--- a/utils/cli.js
+++ b/utils/cli.js
@@ -67,6 +67,11 @@ module.exports = meow(
 				type: 'boolean',
 				default: false,
 				alias: 'm'
+			},
+			json: {
+				type: 'boolean',
+				default: false,
+				alias: 'j'
 			}
 		}
 	}

--- a/utils/cli.js
+++ b/utils/cli.js
@@ -18,6 +18,7 @@ module.exports = meow(
 	  ${yellow(`--sort`)}, ${yellow(`-s`)}           Sort data by type
 	  ${yellow(`--reverse`)}, ${yellow(`-r`)}        Reverse print order
 	  ${yellow(`--limit`)}, ${yellow(`-l`)}          Print only N entries
+	  ${yellow(`--json`)}, ${yellow(`-j`)}           Output as JSON
 
 	Examples
 	  ${green(`corona`)} ${cyan(`china`)}

--- a/utils/getCountries.js
+++ b/utils/getCountries.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const chalk = require('chalk');
 const cyan = chalk.cyan;
 const dim = chalk.dim;
-const comma = require('comma-number');
+const numberFormat = require('./numberFormat');
 const { sortingKeys } = require('./table.js');
 const to = require('await-to-js').default;
 const handleError = require('cli-handle-error');
@@ -10,10 +10,10 @@ const orderBy = require('lodash.orderby');
 
 module.exports = async (
 	spinner,
-	table,
+	output,
 	states,
 	countryName,
-	{ sortBy, limit, reverse }
+	{ sortBy, limit, reverse, json }
 ) => {
 	if (!countryName && !states) {
 		const [err, response] = await to(
@@ -25,6 +25,9 @@ module.exports = async (
 		// Limit.
 		allCountries = allCountries.slice(0, limit);
 
+		// Format.
+		const format = numberFormat(json);
+
 		// Sort & reverse.
 		const direction = reverse ? 'asc' : 'desc';
 		allCountries = orderBy(
@@ -35,23 +38,25 @@ module.exports = async (
 
 		// Push selected data.
 		allCountries.map((oneCountry, count) => {
-			table.push([
+			output.push([
 				count + 1,
 				oneCountry.country,
-				comma(oneCountry.cases),
-				comma(oneCountry.todayCases),
-				comma(oneCountry.deaths),
-				comma(oneCountry.todayDeaths),
-				comma(oneCountry.recovered),
-				comma(oneCountry.active),
-				comma(oneCountry.critical),
-				comma(oneCountry.casesPerOneMillion)
+				format(oneCountry.cases),
+				format(oneCountry.todayCases),
+				format(oneCountry.deaths),
+				format(oneCountry.todayDeaths),
+				format(oneCountry.recovered),
+				format(oneCountry.active),
+				format(oneCountry.critical),
+				format(oneCountry.casesPerOneMillion)
 			]);
 		});
 
 		spinner.stopAndPersist();
 		const isRev = reverse ? `${dim(` & `)}${cyan(`Order`)}: reversed` : ``;
-		spinner.info(`${cyan(`Sorted by:`)} ${sortBy}${isRev}`);
-		console.log(table.toString());
+		if (!json) {
+			spinner.info(`${cyan(`Sorted by:`)} ${sortBy}${isRev}`);
+			console.log(output.toString());
+		}
 	}
 };

--- a/utils/getCountry.js
+++ b/utils/getCountry.js
@@ -1,7 +1,7 @@
 const chalk = require('chalk');
 const axios = require('axios');
 const sym = require('log-symbols');
-const comma = require('comma-number');
+const numberFormat = require('./numberFormat');
 const red = chalk.red;
 const to = require('await-to-js').default;
 const handleError = require('cli-handle-error');
@@ -24,17 +24,20 @@ module.exports = async (spinner, table, states, countryName, options) => {
 			process.exit(0);
 		}
 
+		// Format.
+		const format = numberFormat(options.json);
+
 		table.push([
 			`—`,
 			thisCountry.country,
-			comma(thisCountry.cases),
-			comma(thisCountry.todayCases),
-			comma(thisCountry.deaths),
-			comma(thisCountry.todayDeaths),
-			comma(thisCountry.recovered),
-			comma(thisCountry.active),
-			comma(thisCountry.critical),
-			comma(thisCountry.casesPerOneMillion)
+			format(thisCountry.cases),
+			format(thisCountry.todayCases),
+			format(thisCountry.deaths),
+			format(thisCountry.todayDeaths),
+			format(thisCountry.recovered),
+			format(thisCountry.active),
+			format(thisCountry.critical),
+			format(thisCountry.casesPerOneMillion)
 		]);
 		spinner.stopAndPersist();
 		console.log(table.toString());

--- a/utils/getStates.js
+++ b/utils/getStates.js
@@ -2,13 +2,13 @@ const axios = require('axios');
 const chalk = require('chalk');
 const cyan = chalk.cyan;
 const dim = chalk.dim;
-const comma = require('comma-number');
+const numberFormat = require('./numberFormat');
 const { sortingStateKeys } = require('./table.js');
 const to = require('await-to-js').default;
 const handleError = require('cli-handle-error');
 const orderBy = require('lodash.orderby');
 
-module.exports = async (spinner, table, states, { sortBy, limit, reverse }) => {
+module.exports = async (spinner, output, states, { sortBy, limit, reverse, json }) => {
 	if (states) {
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/states`)
@@ -19,26 +19,31 @@ module.exports = async (spinner, table, states, { sortBy, limit, reverse }) => {
 		// Limit.
 		allStates = allStates.slice(0, limit);
 
+		// Format.
+		const format = numberFormat(json);
+
 		// Sort & reverse.
 		const direction = reverse ? 'asc' : 'desc';
 		allStates = orderBy(allStates, [sortingStateKeys[sortBy]], [direction]);
 
 		// Push selected data.
 		allStates.map((oneState, count) => {
-			table.push([
+			output.push([
 				count + 1,
 				oneState.state,
-				comma(oneState.cases),
-				comma(oneState.todayCases),
-				comma(oneState.deaths),
-				comma(oneState.todayDeaths),
-				comma(oneState.active)
+				format(oneState.cases),
+				format(oneState.todayCases),
+				format(oneState.deaths),
+				format(oneState.todayDeaths),
+				format(oneState.active)
 			]);
 		});
 
 		spinner.stopAndPersist();
 		const isRev = reverse ? `${dim(` & `)}${cyan(`Order`)}: reversed` : ``;
-		spinner.info(`${cyan(`Sorted by:`)} ${sortBy}${isRev}`);
-		console.log(table.toString());
+		if (!json) {
+			spinner.info(`${cyan(`Sorted by:`)} ${sortBy}${isRev}`);
+			console.log(output.toString());
+		}
 	}
 };

--- a/utils/getWorldwide.js
+++ b/utils/getWorldwide.js
@@ -1,13 +1,14 @@
 const axios = require('axios');
-const comma = require('comma-number');
+const numberFormat = require('./numberFormat');
 const to = require('await-to-js').default;
 const handleError = require('cli-handle-error');
 
-module.exports = async (table, states) => {
+module.exports = async (table, states, json) => {
 	const [err, all] = await to(axios.get(`https://corona.lmao.ninja/all`));
 	handleError(`API is down, try again later.`, err, false);
 	let data = Object.values(all.data);
-	data = data.map(d => comma(d));
+	const format = numberFormat(json);
+	data = data.map(d => format(d));
 
 	if (!states) {
 		table.push([

--- a/utils/init.js
+++ b/utils/init.js
@@ -4,10 +4,10 @@ const pkgJSON = require('./../package.json');
 const updateNotifier = require('update-notifier');
 const unhandledError = require('cli-handle-unhandled');
 
-module.exports = async () => {
+module.exports = async (skipWelcome = false) => {
 	unhandledError();
 	checkNode(`12`);
-	welcome(`corona-cli`, `by Awais.dev\n${pkgJSON.description}`, {
+	!skipWelcome && welcome(`corona-cli`, `by Awais.dev\n${pkgJSON.description}`, {
 		bgColor: `#007C91`,
 		color: `#FFFFFF`,
 		bold: true,

--- a/utils/numberFormat.js
+++ b/utils/numberFormat.js
@@ -1,0 +1,4 @@
+const commaNumber = require('comma-number');
+const plain = num => num;
+
+module.exports = json => json ? plain : commaNumber;

--- a/utils/table.js
+++ b/utils/table.js
@@ -1,8 +1,10 @@
 const chalk = require('chalk');
-const green = chalk.green;
-const red = chalk.red;
-const yellow = chalk.yellow;
-const dim = chalk.dim;
+const cli = require('./cli');
+const plain = text => text;
+const green = cli.flags.json ? plain : chalk.green;
+const red = cli.flags.json ? plain : chalk.red;
+const yellow = cli.flags.json ? plain : chalk.yellow;
+const dim = cli.flags.json ? plain : chalk.dim;
 
 module.exports = {
 	single: [

--- a/utils/theEnd.js
+++ b/utils/theEnd.js
@@ -1,5 +1,6 @@
 const sym = require('log-symbols');
 const chalk = require('chalk');
+const JsonOutput = require('./JsonOutput');
 const cyan = chalk.cyan;
 const dim = chalk.dim;
 
@@ -33,7 +34,8 @@ ${dim(`❯ `)}${cyan(`Per Million:`)} Affected patients per million
 `)
 	);
 
-module.exports = async (lastUpdated, states, minimal) => {
+module.exports = async (lastUpdated, states, minimal, output) => {
+	if (output instanceof JsonOutput) return console.log(output.format());
 	if (minimal) return console.log();
 	console.log(dim(`${sym.info} ${cyan(`Last Updated:`)} ${lastUpdated}`));
 	states && infoStates();


### PR DESCRIPTION
## issue #11 

## Overview

This PR is about changing the output format from `Table` to `JsonOutput` (a simplified Json formatter). It doesn't change anything about current logic in regards to data fetching and sorting. The only difference is that:

* All other outputs are silenced, so you can `corona --json > output.json`
* Changes the format of numbers to not use `comma-number`, but instead return plain integers
* When `cli.flags.json === true` all coloring functions in `utils/table.js` will return plain text instead
* Outputs JSON

## How to test
* `corona --json` - normal run
* `corona -j` - same as above using short-handle 
* `corona --json > output.json` - output to `output.json` and check the formatting (Prettifying JSON helps)