### PR TITLE
📦 NEW: Bar chart

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const handleError = require('cli-handle-error');
 const getStates = require('./utils/getStates.js');
 const getCountry = require('./utils/getCountry.js');
 const getCountryChart = require('./utils/getCountryChart.js');
+const getBar = require('./utils/getBar.js');
 const getWorldwide = require('./utils/getWorldwide.js');
 const getCountries = require('./utils/getCountries.js');
 const {
@@ -36,8 +37,9 @@ const reverse = cli.flags.reverse;
 const limit = Math.abs(cli.flags.limit);
 const chart = cli.flags.chart;
 const log = cli.flags.log;
+const bar = cli.flags.bar;
 const minimal = cli.flags.minimal;
-const options = { sortBy, limit, reverse, minimal, chart, log };
+const options = { sortBy, limit, reverse, minimal, chart, log , bar};
 
 (async () => {
 	// Init.
@@ -61,6 +63,7 @@ const options = { sortBy, limit, reverse, minimal, chart, log };
 	await getStates(spinner, table, states, options);
 	await getCountries(spinner, table, states, country, options);
 	await getCountryChart(spinner, country, options);
+    await getBar(spinner, country, states, options);
 
 	theEnd(lastUpdated, states, minimal);
 })();

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ const options = { sortBy, limit, reverse, minimal, chart, log , bar};
 	await getStates(spinner, table, states, options);
 	await getCountries(spinner, table, states, country, bar, options);
 	await getCountryChart(spinner, country, options);
-    await getBar(spinner, country, states, options);
+	await getBar(spinner, country, states, options);
 
 	theEnd(lastUpdated, states, minimal);
 })();

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ const options = { sortBy, limit, reverse, minimal, chart, log , bar};
 	const lastUpdated = await getWorldwide(table, states);
 	await getCountry(spinner, table, states, country, options);
 	await getStates(spinner, table, states, options);
-	await getCountries(spinner, table, states, country, options);
+	await getCountries(spinner, table, states, country, bar, options);
 	await getCountryChart(spinner, country, options);
     await getBar(spinner, country, states, options);
 

--- a/utils/cli.js
+++ b/utils/cli.js
@@ -19,7 +19,7 @@ module.exports = meow(
 	${yellow(`--limit`)}, ${yellow(`-l`)}          Print only N entries
 	${yellow(`--chart`)}, ${yellow(`-c`)}          Print chart for a country
 	${yellow(`--log`)}, ${yellow(`-g`)}            Print logarithmic chart
-    ${yellow('--bar')},${yellow('-b')}             Print bar chart of cases per country
+	${yellow('--bar')},${yellow('-b')}             Print bar chart of cases per country
 	${yellow(`--xcolor`)}, ${yellow(`-x`)}         Single colored output
 	${yellow(`--minimal`)}, ${yellow(`-m`)}        Minimalistic CLI output
 

--- a/utils/cli.js
+++ b/utils/cli.js
@@ -19,6 +19,7 @@ module.exports = meow(
 	${yellow(`--limit`)}, ${yellow(`-l`)}          Print only N entries
 	${yellow(`--chart`)}, ${yellow(`-c`)}          Print chart for a country
 	${yellow(`--log`)}, ${yellow(`-g`)}            Print logarithmic chart
+    ${yellow('--bar')},${yellow('-b')}             Print bar chart of cases per country
 	${yellow(`--xcolor`)}, ${yellow(`-x`)}         Single colored output
 	${yellow(`--minimal`)}, ${yellow(`-m`)}        Minimalistic CLI output
 
@@ -68,6 +69,13 @@ module.exports = meow(
 				default: false,
 				alias: 'g'
 			},
+            //ME
+            bar: {
+				type: 'boolean',
+				default: false,
+				alias: 'b'
+			},
+            //
 			minimal: {
 				type: 'boolean',
 				default: false,

--- a/utils/cli.js
+++ b/utils/cli.js
@@ -69,13 +69,11 @@ module.exports = meow(
 				default: false,
 				alias: 'g'
 			},
-            //ME
-            bar: {
+			bar: {
 				type: 'boolean',
 				default: false,
 				alias: 'b'
 			},
-            //
 			minimal: {
 				type: 'boolean',
 				default: false,

--- a/utils/getBar.js
+++ b/utils/getBar.js
@@ -1,0 +1,75 @@
+const comma = require('comma-number');
+const handleError = require('cli-handle-error');
+const axios = require('axios');
+const to = require('await-to-js').default;
+const moment = require('moment');
+const blessed = require('blessed');
+const contrib = require('blessed-contrib');
+const { sortingKeys } = require('./table.js');
+const orderBy = require('lodash.orderby');
+
+module.exports = async (spinner, countryName, states, { bar, log, sortBy, limit, reverse }) => {
+	if (!countryName && !states && bar) {
+		const [err, response] = await to(
+			axios.get(`https://corona.lmao.ninja/v2/countries`)
+		);
+		handleError(`API is down, try again later.`, err, false);
+        let allCountries = response.data;
+
+        // Sort & reverse.
+		const direction = reverse ? 'asc' : 'desc';
+		allCountries = orderBy(
+			allCountries,
+			[sortingKeys[sortBy]],
+			[direction]
+		);
+        // Limit.
+        limit = limit>12 ? 12: limit;
+		allCountries = allCountries.slice(0, limit);
+
+
+        let logScale = x => x;
+		if (log) {
+			logScale = x => (x === 0 ? undefined : Math.log(x));
+		}
+        // Format Stack Data
+        barCountries = {};
+        allCountries.map((country, count)=>{
+            barCountries[country.country]=[
+                logScale(country.cases),
+                logScale(country.deaths),
+                logScale(country.recovered)
+            ];
+        });
+
+        const names = Object.keys(barCountries);
+        const data = Object.values(barCountries);
+
+        const screen = blessed.screen();
+
+        const stack = contrib.stackedBar(
+           { label: 'Total Case Comparison'
+           , barWidth: 10
+           , barSpacing: 10
+           , xOffset: 0
+           //, maxValue: 15
+           , height: "100%"
+           , width: "100%"
+           , barBgColor: [ 'cyan', 'red', 'green' ]})
+
+        screen.append(stack);
+        spinner.stop();
+        stack.setData(
+           { barCategory: names
+           , stackedCategory: ['CASES', 'DEATHS', 'RECOVERED']
+           , data:
+              data
+          });
+		screen.render();
+		await new Promise((resolve, _) => {
+			screen.key(['escape', 'q', 'C-c', 'enter', 'space'], (ch, key) => {
+				return process.exit(0);
+			});
+		});
+	}
+};

--- a/utils/getBar.js
+++ b/utils/getBar.js
@@ -45,10 +45,12 @@ module.exports = async (spinner, countryName, states, { bar, log, sortBy, limit,
         const names = Object.keys(barCountries);
         const data = Object.values(barCountries);
 
+		const cumulative = (a, b) => (a = a + b);
+
         const screen = blessed.screen();
 
         const stack = contrib.stackedBar(
-           { label: 'Total Case Comparison'
+           { label: 'Total Cases'
            , barWidth: 10
            , barSpacing: 10
            , xOffset: 0

--- a/utils/getCountries.js
+++ b/utils/getCountries.js
@@ -13,7 +13,7 @@ module.exports = async (
 	table,
 	states,
 	countryName,
-    bar,
+	bar,
 	{ sortBy, limit, reverse }
 ) => {
 	if (!countryName && !states && !bar) {

--- a/utils/getCountries.js
+++ b/utils/getCountries.js
@@ -13,9 +13,10 @@ module.exports = async (
 	table,
 	states,
 	countryName,
+    bar,
 	{ sortBy, limit, reverse }
 ) => {
-	if (!countryName && !states) {
+	if (!countryName && !states && !bar) {
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/v2/countries`)
 		);

--- a/utils/getCountryChart.js
+++ b/utils/getCountryChart.js
@@ -7,6 +7,7 @@ const blessed = require('blessed');
 const contrib = require('blessed-contrib');
 
 module.exports = async (spinner, countryName, { chart, log }) => {
+    console.log("CHART: " + log)
 	if (countryName && chart) {
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/v2/historical/${countryName}`)

--- a/utils/getCountryChart.js
+++ b/utils/getCountryChart.js
@@ -7,7 +7,6 @@ const blessed = require('blessed');
 const contrib = require('blessed-contrib');
 
 module.exports = async (spinner, countryName, { chart, log }) => {
-    console.log("CHART: " + log)
 	if (countryName && chart) {
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/v2/historical/${countryName}`)


### PR DESCRIPTION
Added stacked bar charts for Cases + Deaths + Recovered. 
Incorporates sorting tags and options for displaying.

Examples:
   ` corona --bar`
    `corona --bar -s critical`
    `corona --bar --limit 8` (default limit is 12)

To Do:
    - add different feature comparisons such as daily or critical comparison
    - fix center bar labels. 