### PR TITLE
📦 NEW: States bar

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ const options = { sortBy, limit, reverse, minimal, chart, log, json, bar };
 	spinner.start();
 	const lastUpdated = await getWorldwide(output, states, json);
 	await getCountry(spinner, output, states, country, options);
-	await getStates(spinner, output, states, options);
+	await getStates(spinner, output, states, bar, options);
 	await getCountries(spinner, output, states, country, bar, options);
 	await getCountryChart(spinner, country, options);
 	await getBar(spinner, country, states, options);

--- a/utils/getBar.js
+++ b/utils/getBar.js
@@ -25,17 +25,6 @@ module.exports = async (
 			logScale = x => (x === 0 ? undefined : Math.log(x));
 		}
 
-		// Better colors.
-		const getColors = {
-			cases: 'cyan',
-			'cases-today': 'cyan',
-			deaths: 'red',
-			'deaths-today': 'red',
-			recovered: 'green',
-			active: 'yellow',
-			critical: 'red',
-			'per-million': 'cyan'
-		};
 		const screen = blessed.screen();
 
 		const statesURL = `https://corona.lmao.ninja/v2/states`;
@@ -78,6 +67,17 @@ module.exports = async (
 		const names = Object.keys(barRegions);
 		const data = Object.values(barRegions);
 
+		// Better colors.
+		const getColors = {
+			cases: 'cyan',
+			'cases-today': 'cyan',
+			deaths: 'red',
+			'deaths-today': 'red',
+			recovered: 'green',
+			active: 'yellow',
+			critical: 'red',
+			'per-million': 'cyan'
+		};
 		const firstColor = customSort ? getColors[sortBy] : 'cyan';
 
 		const isRev = reverse ? `${dim(` & `)}${cyan(`Order`)}: reversed` : ``;

--- a/utils/getBar.js
+++ b/utils/getBar.js
@@ -7,6 +7,7 @@ const { sortingKeys } = require('./table.js');
 const orderBy = require('lodash.orderby');
 const { cyan, dim } = require('chalk');
 const sortValidation = require('./sortValidation.js');
+const sortStateValidation = require('./sortStateValidation.js');
 
 module.exports = async (
 	spinner,
@@ -14,53 +15,15 @@ module.exports = async (
 	states,
 	{ bar, log, sortBy, limit, reverse }
 ) => {
-	if (!countryName && !states && bar) {
+	if (bar) {
 		// Handle custom sorting and validate it.
-		const customSort = sortValidation(sortBy, spinner);
-
-		const [err, response] = await to(
-			axios.get(`https://corona.lmao.ninja/v2/countries`)
-		);
-		handleError(`API is down, try again later.`, err, false);
-		let allCountries = response.data;
-
-		// Sort & reverse.
-		const direction = reverse ? 'asc' : 'desc';
-		allCountries = orderBy(
-			allCountries,
-			[sortingKeys[sortBy]],
-			[direction]
-		);
-
-		// Limit.
-		limit = limit > 10 ? 10 : limit;
-		allCountries = allCountries.slice(0, limit);
-
+		const customSort = states
+			? sortStateValidation(sortBy, spinner)
+			: sortValidation(sortBy, spinner);
 		let logScale = x => x;
 		if (log) {
 			logScale = x => (x === 0 ? undefined : Math.log(x));
 		}
-
-		// Format Stack Data.
-		barCountries = {};
-
-		allCountries.map(country => {
-			if (customSort) {
-				barCountries[country.country] = [
-					logScale(country[sortingKeys[sortBy]])
-				];
-			} else {
-				barCountries[country.country] = [
-					logScale(country.cases),
-					logScale(country.deaths),
-					logScale(country.recovered)
-				];
-			}
-		});
-
-		const names = Object.keys(barCountries);
-		const data = Object.values(barCountries);
-		const screen = blessed.screen();
 
 		// Better colors.
 		const getColors = {
@@ -73,6 +36,48 @@ module.exports = async (
 			critical: 'red',
 			'per-million': 'cyan'
 		};
+		const screen = blessed.screen();
+
+		const statesURL = `https://corona.lmao.ninja/v2/states`;
+		const countriesURL = `https://corona.lmao.ninja/v2/countries`;
+
+		const [err, response] = await to(
+			axios.get(states ? statesURL : countriesURL)
+		);
+
+		handleError(`API is down, try again later.`, err, false);
+		let allRegions = response.data;
+		// Sort & reverse.
+		const direction = reverse ? 'asc' : 'desc';
+		allRegions = orderBy(allRegions, [sortingKeys[sortBy]], [direction]);
+
+		// Limit.
+		limit = limit > 10 ? 10 : limit;
+		allRegions = allRegions.slice(0, limit);
+
+		// Format Stack Data.
+		barRegions = {};
+		allRegions.map(region => {
+			if (customSort) {
+				barRegions[region[states ? 'state' : 'country']] = [
+					logScale(region[sortingKeys[sortBy]])
+				];
+			} else {
+				barRegions[region[states ? 'state' : 'country']] = [
+					logScale(region.cases),
+					logScale(region.deaths),
+					logScale(
+						states
+							? region.cases - region.active - region.deaths
+							: region.recovered
+					)
+				];
+			}
+		});
+
+		const names = Object.keys(barRegions);
+		const data = Object.values(barRegions);
+
 		const firstColor = customSort ? getColors[sortBy] : 'cyan';
 
 		const isRev = reverse ? `${dim(` & `)}${cyan(`Order`)}: reversed` : ``;
@@ -100,6 +105,7 @@ module.exports = async (
 					: ['CASES', 'DEATHS', 'RECOVERED'],
 			data: data
 		});
+
 		screen.render();
 
 		await new Promise((resolve, _) => {

--- a/utils/getCountries.js
+++ b/utils/getCountries.js
@@ -15,9 +15,8 @@ module.exports = async (
 	bar,
 	{ sortBy, limit, reverse, json }
 ) => {
-	if (!countryName && !states && !bar) {
+	if (!countryName && !bar) {
 		sortValidation(sortBy, spinner);
-
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/v2/countries`)
 		);

--- a/utils/getStates.js
+++ b/utils/getStates.js
@@ -11,9 +11,10 @@ module.exports = async (
 	spinner,
 	output,
 	states,
+	bar,
 	{ sortBy, limit, reverse, json }
 ) => {
-	if (states) {
+	if (states && !bar) {
 		sortStateValidation(sortBy, spinner);
 		const [err, response] = await to(
 			axios.get(`https://corona.lmao.ninja/v2/states`)


### PR DESCRIPTION
Added `states` command to parameters of getBar.js for bar charts comparing states.
`corona states --bar`

The formatting of barRegions (formerly barCountries) got a little messy because the API returns the data in a different schema for states compared to countries:
 - The key for the region name is `'state'` for states and `'country'`
 - There are no `'recovered'` stats in the response data for states, so I used cases - deaths - 
    active instead.