### PR TITLE
NEW: Added functionality to access individual state data from the command line

### DIFF
--- a/utils/getCountry.js
+++ b/utils/getCountry.js
@@ -6,30 +6,63 @@ const handleError = require('cli-handle-error');
 
 module.exports = async (spinner, table, states, countryName, options) => {
 	if (countryName && !states && !options.chart) {
-		const [err, response] = await to(
-			axios.get(`https://corona.lmao.ninja/v2/countries/${countryName}`)
+
+		const [err, response]  = await to(
+			axios.get(`https://corona.lmao.ninja/v2/states/${countryName}`)
 		);
-		exitCountry(err, spinner, countryName);
-		err && spinner.stopAndPersist();
-		handleError(`API is down, try again later.`, err, false);
-		const thisCountry = response.data;
 
-		// Format.
-		const format = numberFormat(options.json);
+		if (
+			err &&
+			err.response &&
+			err.response.status &&
+			err.response.status === 404
+		) {
+			console.log("hello")
+			const [err, response] = await to(
+				axios.get(`https://corona.lmao.ninja/v2/countries/${countryName}`)
+			);
+			exitCountry(err, spinner, countryName);
+			err && spinner.stopAndPersist();
+			handleError(`API is down, try again later.`, err, false);
+			const thisCountry = response.data
+			// Format.
+			const format = numberFormat(options.json);
 
-		table.push([
-			`—`,
-			thisCountry.country,
-			format(thisCountry.cases),
-			format(thisCountry.todayCases),
-			format(thisCountry.deaths),
-			format(thisCountry.todayDeaths),
-			format(thisCountry.recovered),
-			format(thisCountry.active),
-			format(thisCountry.critical),
-			format(thisCountry.casesPerOneMillion)
-		]);
-		spinner.stopAndPersist();
-		console.log(table.toString());
+			table.push([
+				`—`,
+				thisCountry.country,
+				format(thisCountry.cases),
+				format(thisCountry.todayCases),
+				format(thisCountry.deaths),
+				format(thisCountry.todayDeaths),
+				format(thisCountry.recovered),
+				format(thisCountry.active),
+				format(thisCountry.critical),
+				format(thisCountry.casesPerOneMillion)
+			]);
+			spinner.stopAndPersist();
+			console.log(table.toString());
+		}
+
+		// input is a state
+		else {
+			const thisState = response.data;
+			const format = numberFormat(options.json);
+			table.push([
+				`—`,
+				thisState.state,
+				format(thisState.cases),
+				format(thisState.todayCases),
+				format(thisState.deaths),
+				format(thisState.todayDeaths),
+				format(thisState.recovered),
+				format(thisState.active),
+				"N/A",
+				format(thisState.casesPerOneMillion)
+			]);
+			spinner.stopAndPersist();
+			console.log(table.toString());
+
+		}
 	}
 };


### PR DESCRIPTION
CLI now has the ability to access individual states from the command line. For example "corona california" will display the statistics for only the state of California. Originally only functionality for US states was the command "corona states", which would display the data for all 50 at one time. You can now choose to view one state at a time. 