### PR TITLE
👌 IMPROVE: Added the cases-per-million field for the USA state information

### DIFF
--- a/utils/getStates.js
+++ b/utils/getStates.js
@@ -40,7 +40,8 @@ module.exports = async (
 				format(oneState.todayCases),
 				format(oneState.deaths),
 				format(oneState.todayDeaths),
-				format(oneState.active)
+				format(oneState.active),
+				format(oneState.casesPerOneMillion)
 			]);
 		});
 

--- a/utils/table.js
+++ b/utils/table.js
@@ -39,7 +39,8 @@ module.exports = {
 		`Cases ${dim(`(today)`)}`,
 		`Deaths`,
 		`Deaths ${dim(`(today)`)}`,
-		`Active`
+		`Active`,
+		`Per Million`
 	],
 	coloredStates: [
 		`#`,
@@ -48,7 +49,8 @@ module.exports = {
 		`Cases ${dim(`(today)`)}`,
 		`${red(`Deaths`)}`,
 		`${red(`Deaths (today)`)}`,
-		`${yellow(`Active`)}`
+		`${yellow(`Active`)}`,
+		`Per Million`
 	],
 	style: { head: ['cyan'] },
 	borderless: {
@@ -85,6 +87,7 @@ module.exports = {
 		'cases-today': 'todayCases',
 		deaths: 'deaths',
 		'deaths-today': 'todayDeaths',
-		active: 'active'
+		active: 'active',
+		'per-million': 'casesPerOneMillion'
 	}
 };


### PR DESCRIPTION
This is a very simple change to add the cases-per-million field for the USA state information.  Perhaps
there is some reason why this was excluded earlier?  It's helpful for the same reason that it is included
in the worldwide country-specific stats.